### PR TITLE
Add half cache support

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -659,7 +659,7 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
 {%- macro hip_bulk_template_instantiations(kFixedMaxVecsPerThread, kThreadGroupSize, kUseVecBlocking) %}
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
     {%- for emb_type in ['float', 'at::Half'] %}
-    {%- for cache_type in ['float'] %}
+    {%- for cache_type in ['float', 'at::Half'] %}
     {%- for kEmbeddingDim in [64, 128, 192, 256] %}
     {%- for kWeighDecayMode in [0, 1, 2] %}
         {{ hip_template_instantiation(

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -771,7 +771,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                         {{ hip_kernel }}                        \
                             <emb_t,                             \
                              grad_t,                            \
-                             float, /* FIXME: fp16 cache_t */   \
+                             cache_t,                           \
                              kFixedMaxVecsPerThread,            \
                              kThreadGroupSize,                  \
                              kUseVecBlocking,                   \
@@ -789,7 +789,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                             {%- if not dense %}
                             MAKE_PTA_WITH_NAME(func_name4, dev_weights, emb_t, 1, 64),                                          \
                             MAKE_PTA_WITH_NAME(func_name4, uvm_weights, emb_t, 1, 64),                                          \
-                            MAKE_PTA_WITH_NAME(func_name4, lxu_cache_weights, float, 2, 64),  /* FIXME: fp16 cache_t */         \
+                            MAKE_PTA_WITH_NAME(func_name4, lxu_cache_weights, cache_t, 2, 64),                                  \
                             MAKE_PTA_WITH_NAME(func_name4, weights_placements, int32_t, 1, 32),                                 \
                             {%- else %}
                             MAKE_PTA_WITH_NAME(func_name4, dev_weights, emb_t, 1, 64),                                          \

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1151,10 +1151,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                     const static std::set<int> D_emb_s {64, 128, 192, 256};
                     hip_opt_kernel_supported = (D_emb_s.find(max_D) != D_emb_s.end());
                 }
-                // FIXME: support half as cache_t
-                if (lxu_cache_weights.scalar_type() != at::ScalarType::Float) {
-                    hip_opt_kernel_supported = false;
-                }
+
                 if (hip_opt_kernel_supported) {
                     auto batch_mdiv = [](uint32_t d) -> magic_div_u32_t {
                         assert(d >= 1 && d <= INT32_MAX);

--- a/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
@@ -265,12 +265,13 @@ template <typename to_t, typename from_t>
 requires((sizeof(to_t) == 4 || sizeof(to_t) == 2) && (sizeof(from_t) == 4 || sizeof(from_t) == 2))
 __device__ to_t pack(const from_t& v)
 {
+    to_t result = 0;
     if constexpr(sizeof(to_t) == sizeof(from_t))
     {
-        return __builtin_bit_cast(to_t, v);
+        result = __builtin_bit_cast(to_t, v);
+        return result;
     }
 
-    to_t result = 0;
     memcpy(&result, &v, 2);
 
     return result;

--- a/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
@@ -291,7 +291,11 @@ struct reduce_op_sum_t
 };
 
 #define DPP_REDUCE(OP, TYPE) \
-    __asm__ volatile("v_"#OP"_"#TYPE"_dpp %0 %0 %0 quad_perm:[1,0,3,2]\n" \
+    __asm__ volatile("v_nop\n"                                            \
+                     "v_nop\n"                                            \
+                     "v_nop\n"                                            \
+                     "v_nop\n"                                            \
+                     "v_"#OP"_"#TYPE"_dpp %0 %0 %0 quad_perm:[1,0,3,2]\n" \
                      "v_nop\n"                                            \
                      "v_nop\n"                                            \
                      "v_"#OP"_"#TYPE"_dpp %0 %0 %0 quad_perm:[2,3,0,1]\n" \

--- a/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
@@ -302,6 +302,12 @@ struct reduce_op_sum_t
                      "v_"#OP"_"#TYPE"_dpp %0 %0 %0 row_shr:8\n"           \
                      "v_nop\n"                                            \
                      "v_nop\n"                                            \
+                     "v_"#OP"_"#TYPE"_dpp %0 %0 %0 row_bcast:15\n"        \
+                     "v_nop\n"                                            \
+                     "v_nop\n"                                            \
+                     "v_"#OP"_"#TYPE"_dpp %0 %0 %0 row_bcast:31\n"        \
+                     "v_nop\n"                                            \
+                     "v_nop\n"                                            \
                      : "=v"(result)                                       \
                      : "0"(result))
 

--- a/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
@@ -267,7 +267,7 @@ __device__ to_t pack(const from_t& v)
 {
     if constexpr(sizeof(to_t) == sizeof(from_t))
     {
-        return std::bit_cast<to_t>(v);
+        return __builtin_bit_cast(to_t, v);
     }
 
     to_t result = 0;

--- a/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
@@ -302,24 +302,18 @@ struct reduce_op_sum_t
                      "v_"#OP"_"#TYPE"_dpp %0 %0 %0 row_shr:8\n"           \
                      "v_nop\n"                                            \
                      "v_nop\n"                                            \
-                     "v_"#OP"_"#TYPE"_dpp %0 %0 %0 row_bcast:15\n"        \
-                     "v_nop\n"                                            \
-                     "v_nop\n"                                            \
-                     "v_"#OP"_"#TYPE"_dpp %0 %0 %0 row_bcast:31\n"        \
-                     "v_nop\n"                                            \
-                     "v_nop\n"                                            \
                      : "=v"(result)                                       \
                      : "0"(result))
 
 #define DPP_REDUCE_F16_F32(OP)                       \
     if constexpr (std::is_same_v<data_t, float>)     \
     {                                                \
-        DPP_REDUCE(add, f32);                        \
+        DPP_REDUCE(OP, f32);                        \
     }                                                \
                                                      \
     if constexpr (std::is_same_v<data_t, c10::Half>) \
     {                                                \
-        DPP_REDUCE(add, f16);                        \
+        DPP_REDUCE(OP, f16);                        \
     }
                      
 template<typename data_t, typename reduce_op_t, int wave_size>


### PR DESCRIPTION
Added half cache type support. The main problem was the current "bit_cast" implementation, that was used to pack the values into the int to further pass it with mov_dpp and readlane builtins. So in this PR:

- Reworked bit_cast function to be able to pack and unpack fp16 in int and vice versa
- Reworked wave_reduce() function to use according assembly instructions for simple reduce operations. Left custom reduce operation specification support with old implementation.
- Added half cache template generation