### PR TITLE
Fix unit tests for new performance kernel

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -539,13 +539,20 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
     auto p_sorted_linear_indices_num_runs = sorted_linear_indices_num_runs.data();
     auto p_sorted_infos = sorted_infos.data();
     // max_segment_length_per_warp = max_segment_length_per_warp;
-    // indice_weights_sorted = indice_weights_sorted.packed_accessor32<float, 1, at::RestrictPtrTraits>().data();
+    {%- if weighted %}
+    auto p_indice_weights_sorted = sorted_indice_weights.data();
+    {%- endif %}
     auto emb_dim = embedding_dim;
     constexpr int32_t segment_prefetch = 2; // always 2 in split_bwd.hip
     constexpr int32_t segment_unroll = 8;   // always 8 in split_bwd.hip
     constexpr int32_t segment_split = 0;    // always 0 in split_bwd.hip
     // avbokovoy: num_rows and num_tables should come from outside
     // num_rows = dev_weights.numel() / T / max_D;
+    {%- if weighted %}
+    constexpr bool is_weighted = true;
+    {%- else %}
+    constexpr bool is_weighted = false;
+    {%- endif %}
     split_tbe_backward_hip_kernel_{{kdesc}}<
         {{optimizer}}_optimizer_t<cache_t, emb_t, embedding_dim, weight_decay_mode>,
         {{optimizer}}_kernel_arg_t,
@@ -557,7 +564,7 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
         segment_prefetch,
         segment_unroll,
         segment_split,
-        false>(p_output_grad,
+        is_weighted>(p_output_grad,
                p_emb_table,
                p_hash_size_cumsum,
                p_sorted_linear_indices_run,
@@ -574,7 +581,10 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
                batch,
                num_rows,
                T,
-               opt_karg);
+               opt_karg
+               {%- if weighted %}
+               , p_indice_weights_sorted
+               {%- endif %});
 }
 
 {%- macro hip_template_instantiation(

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -781,7 +781,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
 #define INVOKE_BACKWARD_WARP_PER_ROW_KERNEL() do {                                                                              \
                     hip_backward_warp_per_row_kernel                                                                            \
                         <<<warp_per_row_grid_size,                                                                              \
-                            dim3(kThreadGroupSize, num_warp_per_row_groups),                                                    \
+                            256,                                                    \
                             0,                                                                                                  \
                             at::cuda::getCurrentCUDAStream()>>>(                                                                \
                             grad_output_accessor,                                                                               \
@@ -1134,15 +1134,12 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                 const auto func_name4 = "{{ warp_kernel }}";
 #endif
                 int32_t num_warp_per_row_groups = kBackwardMaxThreads / kThreadGroupSize;
-                const int32_t warp_per_row_grid_size = std::min(
+                int32_t warp_per_row_grid_size = std::min(
                     div_round_up(total_unique_indices, num_warp_per_row_groups),
                     get_max_thread_blocks_());
 
                 // PR23: Call accelerated kernel if suitable
-                static bool once_file = [](){
                     std::cout << "Calling Kernel at file" << __FILE__ << " Line: " << __LINE__ << std::endl;
-                    return true;
-                } ();
 
                 {%- if is_rocm and not is_index_select %}
                 bool hip_opt_kernel_supported = false;      // TODO: figure out support range
@@ -1169,6 +1166,8 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                         result.shift = shift;
                         return result;
                     }(B);
+                    constexpr int segments_per_workgroup = 4;
+                    warp_per_row_grid_size = div_round_up(sorted_linear_indices_run.numel(), segments_per_workgroup);
                     // FIXME: The template if-endif below seems redudant. Consider removing it
                     {%- if optimizer == "rowwise_adagrad" and not dense %}
                     rowwise_adagrad_kernel_arg_t opt_karg;
@@ -1180,11 +1179,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                     opt_karg.weight_decay = weight_decay;
                     {%- endif %}
 
-                    // DEBUG
-                    static bool once = [](){
                         std::cout << "Calling HIP Perf Kernel" << std::endl;
-                        return true;
-                    } ();
                     {%- if nobag %}
                     std::cout << "[DEBUG]: Calling nobag Perf Kernel" << std::endl;
                     {%- endif %}

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1139,7 +1139,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                     get_max_thread_blocks_());
 
                 // PR23: Call accelerated kernel if suitable
-                    std::cout << "Calling Kernel at file" << __FILE__ << " Line: " << __LINE__ << std::endl;
+                std::cout << "Calling Kernel at file" << __FILE__ << " Line: " << __LINE__ << std::endl;
 
                 {%- if is_rocm and not is_index_select %}
                 bool hip_opt_kernel_supported = false;      // TODO: figure out support range
@@ -1179,7 +1179,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                     opt_karg.weight_decay = weight_decay;
                     {%- endif %}
 
-                        std::cout << "Calling HIP Perf Kernel" << std::endl;
+                    std::cout << "Calling HIP Perf Kernel" << std::endl;
                     {%- if nobag %}
                     std::cout << "[DEBUG]: Calling nobag Perf Kernel" << std::endl;
                     {%- endif %}

--- a/fbgemm_gpu/codegen/training/backward/rocm/embedding_backward_split_device_kernel_template.hip
+++ b/fbgemm_gpu/codegen/training/backward/rocm/embedding_backward_split_device_kernel_template.hip
@@ -228,11 +228,21 @@ if constexpr (weighted) {
     // LOOP
     for(; itr < segment_length_mod; itr += segment_unroll)
     {
+        {%- if nobag %}
         magic_div_u32_run_with_mod(batch_mdiv, infos[0], batch, table_index, bag_index);
+        {%- else %}
+        table_index = infos[0] >> info_B_num_bits;
+        bag_index = infos[0] & info_B_mask;
+        {%- endif %}
         load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
             &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
 
+        {%- if nobag %}
         magic_div_u32_run_with_mod(batch_mdiv, infos[1], batch, table_index, bag_index);
+        {%- else %}
+        table_index = infos[1] >> info_B_num_bits;
+        bag_index = infos[1] & info_B_mask;
+        {%- endif %}
         load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
             &grad_data[dword_per_row], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
         if constexpr (!weighted){
@@ -241,14 +251,23 @@ if constexpr (weighted) {
             {
                 accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                     &grad_acc[0], &grad_data[0], lane_id);
+                {%- if nobag %}
                 magic_div_u32_run_with_mod(batch_mdiv, infos[j], batch, table_index, bag_index);
+                {%- else %}
+                table_index = infos[j] >> info_B_num_bits;
+                bag_index = infos[j] & info_B_mask;
+                {%- endif %}
                 load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                     &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
 
                 accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                     &grad_acc[0], &grad_data[dword_per_row], lane_id);
-                magic_div_u32_run_with_mod(
-                    batch_mdiv, infos[j + 1], batch, table_index, bag_index);
+                {%- if nobag %}
+                magic_div_u32_run_with_mod(batch_mdiv, infos[j + 1], batch, table_index, bag_index);
+                {%- else %}
+                table_index = infos[j + 1] >> info_B_num_bits;
+                bag_index = infos[j + 1] & info_B_mask;
+                {%- endif %}
                 load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                     &grad_data[dword_per_row], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
             }
@@ -272,14 +291,23 @@ if constexpr (weighted) {
             {
                 accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                     &grad_acc[0], &grad_data[0], lane_id, indice_weights[j-2]);
+                {%- if nobag %}
                 magic_div_u32_run_with_mod(batch_mdiv, infos[j], batch, table_index, bag_index);
+                {%- else %}
+                table_index = infos[j] >> info_B_num_bits;
+                bag_index = infos[j] & info_B_mask;
+                {%- endif %}
                 load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                     &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
 
                 accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                     &grad_acc[0], &grad_data[dword_per_row], lane_id, indice_weights[j-1]);
-                magic_div_u32_run_with_mod(
-                    batch_mdiv, infos[j + 1], batch, table_index, bag_index);
+                {%- if nobag %}
+                magic_div_u32_run_with_mod(batch_mdiv, infos[j + 1], batch, table_index, bag_index);
+                {%- else %}
+                table_index = infos[j + 1] >> info_B_num_bits;
+                bag_index = infos[j + 1] & info_B_mask;
+                {%- endif %}
                 load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                     &grad_data[dword_per_row], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
             }
@@ -301,11 +329,21 @@ if constexpr (weighted) {
     }
 
     // LAST
+    {%- if nobag %}
     magic_div_u32_run_with_mod(batch_mdiv, infos[0], batch, table_index, bag_index);
+    {%- else %}
+    table_index = infos[0] >> info_B_num_bits;
+    bag_index = infos[0] & info_B_mask;
+    {%- endif %}
     load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
         &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
 
+    {%- if nobag %}
     magic_div_u32_run_with_mod(batch_mdiv, infos[1], batch, table_index, bag_index);
+    {%- else %}
+    table_index = infos[1] >> info_B_num_bits;
+    bag_index = infos[1] & info_B_mask;
+    {%- endif %}
     load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
         &grad_data[dword_per_row], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
 
@@ -315,13 +353,23 @@ if constexpr (weighted) {
         {
             accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                 &grad_acc[0], &grad_data[0], lane_id);
+            {%- if nobag %}
             magic_div_u32_run_with_mod(batch_mdiv, infos[j], batch, table_index, bag_index);
+            {%- else %}
+            table_index = infos[j] >> info_B_num_bits;
+            bag_index = infos[j] & info_B_mask;
+            {%- endif %}
             load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                 &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
 
             accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                 &grad_acc[0], &grad_data[dword_per_row], lane_id);
+            {%- if nobag %}
             magic_div_u32_run_with_mod(batch_mdiv, infos[j + 1], batch, table_index, bag_index);
+            {%- else %}
+            table_index = infos[j + 1] >> info_B_num_bits;
+            bag_index = infos[j + 1] & info_B_mask;
+            {%- endif %}
             load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                 &grad_data[dword_per_row], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
         }
@@ -336,13 +384,23 @@ if constexpr (weighted) {
         {
             accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                 &grad_acc[0], &grad_data[0], lane_id, indice_weights[j-2]);
+            {%- if nobag %}
             magic_div_u32_run_with_mod(batch_mdiv, infos[j], batch, table_index, bag_index);
+            {%- else %}
+            table_index = infos[j] >> info_B_num_bits;
+            bag_index = infos[j] & info_B_mask;
+            {%- endif %}
             load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                 &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
 
             accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
                 &grad_acc[0], &grad_data[dword_per_row], lane_id, indice_weights[j-1]);
+            {%- if nobag %}
             magic_div_u32_run_with_mod(batch_mdiv, infos[j + 1], batch, table_index, bag_index);
+            {%- else %}
+            table_index = infos[j + 1] >> info_B_num_bits;
+            bag_index = infos[j + 1] & info_B_mask;
+            {%- endif %}
             load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                 &grad_data[dword_per_row], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
         }
@@ -363,7 +421,12 @@ L_tail_grad_acc:
                 infos[0] = p_sorted_infos[segment_start];
                 p_sorted_infos++;
 
+                {%- if nobag %}
                 magic_div_u32_run_with_mod(batch_mdiv, infos[0], batch, table_index, bag_index);
+                {%- else %}
+                table_index = infos[0] >> info_B_num_bits;
+                bag_index = infos[0] & info_B_mask;
+                {%- endif %}
                 load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                     &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
                 accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(
@@ -379,7 +442,12 @@ L_tail_grad_acc:
                 p_sorted_infos++;
                 p_sorted_indice_weights++;
 
+                {%- if nobag %}
                 magic_div_u32_run_with_mod(batch_mdiv, infos[0], batch, table_index, bag_index);
+                {%- else %}
+                table_index = infos[0] >> info_B_num_bits;
+                bag_index = infos[0] & info_B_mask;
+                {%- endif %}
                 load_row_per_warp<grad_t, embedding_dim, int32_t>::run(
                     &grad_data[0], bag_index * num_tables, p_output_grad + table_index * embedding_dim, lane_id);
                 accumulate_row_per_warp<grad_t, embedding_dim, cache_t, weighted>::run(

--- a/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
+++ b/fbgemm_gpu/include/fbgemm_gpu/hip_kernel_inc/split_embeddings_common.h
@@ -359,7 +359,7 @@ __device__ __forceinline__ void generic_dpp_reduction(data_t& result)
     if constexpr(wave_size > 4)
     {
         result =
-            pack(result,
+            reduce_op(result,
                       pack<data_t, int>(__builtin_amdgcn_mov_dpp(pack<int, data_t>(result),
                                                                      0x114,
                                                                      row_mask,

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -869,6 +869,84 @@ class BackwardOptimizersTest(unittest.TestCase):
             weight_decay_mode,
         )
 
+# This is a temporary test just to assess new kernel.
+# Should be removed
+    @given(
+        T=st.integers(min_value=1, max_value=5),
+        D=st.sampled_from([16, 32, 48, 64]),
+        B=st.integers(min_value=1, max_value=128),
+        log_E=st.integers(min_value=3, max_value=5),
+        L=st.integers(min_value=2, max_value=20),
+        weighted=st.booleans(),
+        mixed=st.just(False),
+        mixed_B=st.just(False),
+        optimizer=st.sampled_from(
+            [
+                OptimType.EXACT_ROWWISE_ADAGRAD,
+            ]
+        ),
+        long_segments=st.booleans(),
+        pooling_mode=st.sampled_from(
+            [
+                PoolingMode.SUM,
+                PoolingMode.NONE,
+            ]
+        ),
+        use_cpu=st.just(False),
+        weight_decay_mode=st.sampled_from(
+            [
+                WeightDecayMode.NONE,
+                WeightDecayMode.L2,
+                WeightDecayMode.DECOUPLE,
+                WeightDecayMode.COUNTER,
+                WeightDecayMode.COWCLIP,
+            ]
+        ),
+    )
+    @settings(
+        verbosity=VERBOSITY,
+        max_examples=MAX_EXAMPLES_LONG_RUNNING,
+        deadline=None,
+        suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.data_too_large],
+    )
+    @unittest.skipIf(*gpu_unavailable)
+    def test_new_bwd_kernel(  # noqa C901
+        self,
+        T: int,
+        D: int,
+        B: int,
+        log_E: int,
+        L: int,
+        weighted: bool,
+        mixed: bool,
+        mixed_B: bool,
+        optimizer: OptimType,
+        long_segments: bool,
+        pooling_mode: PoolingMode,
+        use_cpu: bool,
+        weight_decay_mode: WeightDecayMode,
+    ) -> None:
+        if (
+            pooling_mode == PoolingMode.NONE
+            or optimizer != OptimType.EXACT_ROWWISE_ADAGRAD
+        ):
+            mixed_B = False
+        self.execute_backward_optimizers_(
+            T,
+            D,
+            B,
+            log_E,
+            L,
+            weighted,
+            mixed,
+            mixed_B,
+            optimizer,
+            long_segments,
+            pooling_mode,
+            use_cpu,
+            weight_decay_mode,
+        )
+
     @given(
         T=st.integers(min_value=1, max_value=5),
         D=st.integers(min_value=2, max_value=256),

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -889,7 +889,7 @@ class BackwardOptimizersTest(unittest.TestCase):
         pooling_mode=st.sampled_from(
             [
                 PoolingMode.SUM,
-                PoolingMode.NONE,
+                # PoolingMode.NONE,
             ]
         ),
         use_cpu=st.just(False),

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -898,8 +898,8 @@ class BackwardOptimizersTest(unittest.TestCase):
                 WeightDecayMode.NONE,
                 WeightDecayMode.L2,
                 WeightDecayMode.DECOUPLE,
-                WeightDecayMode.COUNTER,
-                WeightDecayMode.COWCLIP,
+                # WeightDecayMode.COUNTER,
+                # WeightDecayMode.COWCLIP,
             ]
         ),
     )


### PR DESCRIPTION
This PR addresses several issues, that are currently presented in kernel port:

- Added temporary unit test that assesses bwd kernel support range
- Fixed weighted mode
- Fixed wrong block and grid sizes

Command to launch new unit test (from fbgemm/test folder):
```shell
FBGEMM_TEST_WITH_ROCM=1 python -m tbe.training.backward_optimizers_test -k test_new_bwd_kernel
``` 
Current support range:

- **embeddings dimensions:** {64, 128, 192, 256}
- **weighted/unweighted:** supported
- **weight decay modes:** None, L2, DECOUPLE
- **nobag mode:** doesn't work properly (need to fix indexing)
- **optimizer:** rowwise_adagrad
- **mixed/mixed_B:** not supported
- **long segments:** supported

Unfortunately, previous unit tests that we used passed just because it didn't test new bwd kernel