### PR TITLE
Add 160 embedding size support

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_kernel_warp_template.cu
@@ -696,7 +696,7 @@ hip_split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}{{ vd
     {%- for grad_type in ['float', 'at::Half', 'at::BFloat16'] %}
     {%- for emb_type in ['float', 'at::Half'] %}
     {%- for cache_type in ['float', 'at::Half'] %}
-    {%- for kEmbeddingDim in [64, 128, 192, 256] %}
+    {%- for kEmbeddingDim in [64, 128, 160, 192, 256] %}
     {%- for kWeighDecayMode in [0, 1, 2] %}
         {{ hip_template_instantiation(
             emb_type,

--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -1098,7 +1098,7 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                 {%- if is_rocm and not is_index_select and optimizer == "rowwise_adagrad" and not dense%}
                 bool hip_opt_kernel_supported = false;      // TODO: figure out support range
                 if (dev_weights.scalar_type() == at::ScalarType::Half || dev_weights.scalar_type() == at::ScalarType::Float) {
-                    const static std::set<int> D_emb_s {64, 128, 192, 256};
+                    const static std::set<int> D_emb_s {64, 128, 160, 192, 256};
                     hip_opt_kernel_supported = (D_emb_s.find(max_D) != D_emb_s.end());
                 }
                 if(hip_opt_kernel_supported)
@@ -1114,6 +1114,8 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(64, WDM);
                         } else if (max_D == 128) {
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(128, WDM);
+                        } else if (max_D == 160) {
+                            ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(160, WDM);
                         } else if (max_D == 192) {
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(192, WDM);
                         } else if (max_D == 256) {
@@ -1125,6 +1127,8 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(64, WDM);
                         } else if (max_D == 128) {
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(128, WDM);
+                        } else if (max_D == 160) {
+                            ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(160, WDM);
                         } else if (max_D == 192) {
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(192, WDM);
                         } else if (max_D == 256) {
@@ -1136,6 +1140,8 @@ Tensor split_embedding{{ ndesc }}_backward_codegen_{{ optimizer }}_{{ wdesc }}_e
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(64, WDM);
                         } else if (max_D == 128) {
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(128, WDM);
+                        } else if (max_D == 160) {
+                            ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(160, WDM);
                         } else if (max_D == 192) {
                             ASSIGN_BACKWARD_WARP_PER_ROW_KERNEL(192, WDM);
                         } else if (max_D == 256) {

--- a/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_optimizers_test.py
@@ -873,7 +873,7 @@ class BackwardOptimizersTest(unittest.TestCase):
 # Should be removed
     @given(
         T=st.integers(min_value=1, max_value=5),
-        D=st.sampled_from([16, 32, 48, 64]),
+        D=st.sampled_from([16, 32, 40, 48, 64]),
         B=st.integers(min_value=1, max_value=128),
         log_E=st.integers(min_value=3, max_value=5),
         L=st.integers(min_value=2, max_value=20),


### PR DESCRIPTION
Added experimental support of 160 embedding size. The approach is straight-forward: we fit the last 32 elements of the raw with zeroes to not break current 64 wave reduction. So the performance is around the same as for 192 emb size. I believe that it might be rewritten with the better approach, but let's stick with this one to get some experimental metrics