### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "linux.24xlarge" },
+          { arch: x86, instance: "gfx90a" },
         ]
         container-image: [ "ubuntu:20.04" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
@@ -138,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         host-machine: [
-          { arch: x86, instance: "rocm" },
+          { arch: x86, instance: "gfx90a" },
         ]
         # ROCm machines are limited, so we only test a subset of Python versions
         python-version: [ "3.12" ]

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -190,5 +190,5 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_wheel $BUILD_ENV *.whl
 
     - name: Test with PyTest
-      # timeout-minutes: 20
+      timeout-minutes: 20
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV rocm

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -63,7 +63,7 @@ jobs:
           { arch: x86, instance: "gfx90a" },
         ]
         container-image: [ "ubuntu:20.04" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         rocm-version: [ "6.2" ]
         compiler: [ "gcc", "clang" ]
 

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -190,5 +190,5 @@ jobs:
       run: . $PRELUDE; install_fbgemm_gpu_wheel $BUILD_ENV *.whl
 
     - name: Test with PyTest
-      timeout-minutes: 20
+      # timeout-minutes: 20
       run: . $PRELUDE; cd fbgemm_gpu/test; run_fbgemm_gpu_tests $BUILD_ENV rocm

--- a/.github/workflows/fbgemm_gpu_ci_rocm.yml
+++ b/.github/workflows/fbgemm_gpu_ci_rocm.yml
@@ -64,7 +64,7 @@ jobs:
         ]
         container-image: [ "ubuntu:20.04" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        rocm-version: [ "6.0.2" ]
+        rocm-version: [ "6.2" ]
         compiler: [ "gcc", "clang" ]
 
     steps:
@@ -142,7 +142,7 @@ jobs:
         ]
         # ROCm machines are limited, so we only test a subset of Python versions
         python-version: [ "3.12" ]
-        rocm-version: [ "6.0.2" ]
+        rocm-version: [ "6.2" ]
         compiler: [ "gcc", "clang" ]
     needs: build_artifact
 


### PR DESCRIPTION
### Workflow overview
- 8 build steps, each takes 15-20 minutes (4 python versions * 2 compilers)
- 2 test steps (py3.12 + gcc, py3.12 + clang). 20 minutes timeout for each step

### Current state
- Build steps are stable
- Sometimes tests execution is hang on `quantize/mixed_dim_int8_test.py::TestMixedDimInt8DequantizationConversion::test_mixed_dim_8bit_dequantize_op_large_dims`
  Example (this build was run without timeout): https://github.com/ROCm/FBGEMM/actions/runs/11030723491/job/30643217085#step:15:8856
- Otherwise tests are failed in both steps
  Example: https://github.com/ROCm/FBGEMM/actions/runs/11069852689