### PR TITLE
benchmark with kineto profiler

### DIFF
--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -163,8 +163,10 @@ def benchmark_requests(
 ) -> float:
     times = []
     # Run at least one warmup iteration to avoid the long cudaLaunchKernel time
-    # for the first kernel
-    num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
+    # for the first kernel if warmup_ms > 0
+    # warmup_ms is prioritized over num_warmups
+    if (warmup_ms is None):
+        num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
 
     # warm-up the GPU before profiling
     if warmup_ms:
@@ -188,8 +190,7 @@ def benchmark_requests(
                 out = func(indices, offsets, weights)
                 if bwd_only:
                     out.backward(grad)
-
-    if num_warmups > 0:
+    else:
         indices, offsets, weights = requests[0].unpack_3()
         for _ in range(num_warmups):
             out = func(indices, offsets, weights)

--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -205,20 +205,18 @@ def benchmark_requests(
         num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
 
     # warm-up the GPU before profiling
-    if warmup_ms or num_warmups:
-        warmup(
-            requests[0],
-            warmup_ms,
-            num_warmups,
-            lambda indices, offsets, per_sample_weights: func(
-                indices.int(),
-                offsets.int(),
-                per_sample_weights,
-
-            ),
-            bwd_only=bwd_only,
-            grad=grad,
-        )
+    warmup(
+        requests[0],
+        warmup_ms,
+        num_warmups,
+        lambda indices, offsets, per_sample_weights: func(
+            indices.int(),
+            offsets.int(),
+            per_sample_weights,
+        ),
+        bwd_only=bwd_only,
+        grad=grad,
+    )
 
     if callback_after_warmup is not None:
         callback_after_warmup()

--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -187,7 +187,8 @@ def benchmark_requests(
     # Run at least one warmup iteration to avoid the long cudaLaunchKernel time
     # for the first kernel if warmup_ms > 0
     # warmup_ms is prioritized over num_warmups
-    if (warmup_ms is None):
+
+    if warmup_ms is None:
         num_warmups = num_warmups + 1 if num_warmups >= 0 else 1
 
     # warm-up the GPU before profiling

--- a/fbgemm_gpu/bench/bench_utils.py
+++ b/fbgemm_gpu/bench/bench_utils.py
@@ -40,25 +40,11 @@ def warmup(
 ) -> None:
     indices, offsets, weights = request.unpack_3()
     if warmup_ms:
-        if torch.cuda.is_available():
-            elapsed_time_ms = 0
-            torch.cuda.synchronize()
-            start_events = torch.cuda.Event(enable_timing=True)
-            end_events = torch.cuda.Event(enable_timing=True)
-            while elapsed_time_ms < warmup_ms:
-                start_events.record()
-                out = func(indices, offsets, weights)
-                if bwd_only:
-                    out.backward(grad)
-                end_events.record()
-                torch.cuda.synchronize()
-                elapsed_time_ms += start_events.elapsed_time(end_events)
-        else:
-            start_time_ms = time.time() * 1000
-            while time.time() * 1000 - start_time_ms < warmup_ms:
-                out = func(indices, offsets, weights)
-                if bwd_only:
-                    out.backward(grad)
+        start_time_ms = time.time() * 1000
+        while time.time() * 1000 - start_time_ms < warmup_ms:
+            out = func(indices, offsets, weights)
+            if bwd_only:
+                out.backward(grad)
     else:
         for _ in range(warmup_runs):
             out = func(indices, offsets, weights)

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1331,6 +1331,9 @@ def nbit_device(  # noqa C901
         p.export_chrome_trace(
             trace_url.format(tbe_type=tbe_type, phase=phase, ospid=os.getpid())
         )
+        # averges the sum of all kernels
+        total_cuda_time = sum(event.device_time*event.count/(iters+1) for event in p.key_averages() if event.cpu_time == 0.0)
+        print(f"Total CUDA time: {total_cuda_time:.3f} ")
 
     # pyre-ignore[3]
     def context_factory(on_trace_ready: Callable[[profile], None]):

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1135,6 +1135,7 @@ def nbit_cpu(  # noqa C901
 @click.option("--iters", default=100)
 @click.option("--runs-of-iters", default=5)
 @click.option("--warmup-runs", default=2)
+@click.option("--warmup-ms", type=int, default=None)
 @click.option("--output-dtype", type=SparseType, default=SparseType.FP16)
 @click.option("--report-aibench", is_flag=True)
 @click.option("--run-reference", is_flag=True, default=False)
@@ -1169,6 +1170,7 @@ def nbit_device(  # noqa C901
     iters: int,
     runs_of_iters: int,
     warmup_runs: int,
+    warmup_ms: Optional[int],
     output_dtype: SparseType,
     report_aibench: bool,
     run_reference: bool,
@@ -1295,6 +1297,7 @@ def nbit_device(  # noqa C901
                 per_sample_weights,
             ),
             check_median=check_median,
+            warmup_ms=warmup_ms,
         )
 
         # free up GPU memory

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1410,17 +1410,18 @@ def nbit_device(  # noqa C901
             check_median=check_median,
         )
 
-    kernel_time = time_dict['kernel_time']
-    bandwidth = read_write_bytes / kernel_time / 1.0e3
+    if export_trace:
+        kernel_time = time_dict['kernel_time']
+        bandwidth = read_write_bytes / kernel_time / 1.0e3
 
-    logging.info(
-        f"kineto profiled stats: "
-        f"{weights_precision} Forward, B: {B}, "
-        f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-        f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
-        f"Time: {kernel_time:.0f}us, "
-        f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
-    )
+        logging.info(
+            f"kineto profiled stats: "
+            f"{weights_precision} Forward, B: {B}, "
+            f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
+            f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
+            f"Time: {kernel_time:.0f}us, "
+            f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
+        )
 
     # free up GPU memory
     del requests
@@ -1831,17 +1832,18 @@ def nbit_device_with_spec(  # noqa C901
                 check_median=check_median,
             )
 
-        kernel_time = time_dict['kernel_time']
-        bandwidth = read_write_bytes / kernel_time / 1.0e3
+        if export_trace:
+            kernel_time = time_dict['kernel_time']
+            bandwidth = read_write_bytes / kernel_time / 1.0e3
 
-        logging.info(
-            f"kineto profiled stats: "
-            f"{weights_precision} Forward, B: {B}, "
-            f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
-            f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
-            f"Time: {kernel_time:.0f}us, "
-            f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
-        )
+            logging.info(
+                f"kineto profiled stats: "
+                f"{weights_precision} Forward, B: {B}, "
+                f"E: {E}, T: {T}, D: {D}, L: {L}, W: {weighted}, "
+                f"BW: {bandwidth: .2f} GB/s, "  # noqa: B950
+                f"Time: {kernel_time:.0f}us, "
+                f"Memory Usage For Pruning: {mem_for_pruning / 1.0e9:.0f} GB"
+            )
 
     # free up memory
     del kineto_request

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -95,10 +95,7 @@ else:
 logging.basicConfig(level=logging.DEBUG)
 
 
-def kineto_trace_profiler(
-    p: profile,
-    trace_info: tuple[str, str, str, str]
-) -> float:
+def kineto_trace_profiler(p: profile, trace_info: tuple[str, str, str, str]) -> float:
     phase, trace_url, tbe_type, kern_name = trace_info
     p.export_chrome_trace(
         trace_url.format(tbe_type=tbe_type, phase=phase, ospid=os.getpid())
@@ -1169,13 +1166,15 @@ def nbit_cpu(  # noqa C901
     default="{tbe_type}_tbe_{phase}_trace_{ospid}.json",
 )
 @click.option(
-    "--warmup-runs", default=2,
-    help="Number of warmup runs. Ignored if --warmup-ms is set.")
+    "--warmup-runs",
+    default=2,
+    help="Number of warmup runs. Ignored if --warmup-ms is set.",
+)
 @click.option(
     "--warmup-ms",
     type=int,
     default=None,
-    help="Warmup duration in milliseconds. Disables the --run-nums option."
+    help="Warmup duration in milliseconds. Disables the --run-nums option.",
 )
 def nbit_device(  # noqa C901
     alpha: float,
@@ -1393,7 +1392,7 @@ def nbit_device(  # noqa C901
                 indices.int(),
                 offsets.int(),
                 per_sample_weights,
-            )
+            ),
         )
 
     with context_factory(
@@ -1411,7 +1410,7 @@ def nbit_device(  # noqa C901
         )
 
     if export_trace:
-        kernel_time = time_dict['kernel_time']
+        kernel_time = time_dict["kernel_time"]
         bandwidth = read_write_bytes / kernel_time / 1.0e3
 
         logging.info(
@@ -1536,13 +1535,15 @@ def nbit_device(  # noqa C901
     default="{tbe_type}_tbe_spec_{phase}_trace_{ospid}.json",
 )
 @click.option(
-    "--warmup-runs", default=2,
-    help="Number of warmup runs. Ignored if --warmup-ms is set.")
+    "--warmup-runs",
+    default=2,
+    help="Number of warmup runs. Ignored if --warmup-ms is set.",
+)
 @click.option(
     "--warmup-ms",
     type=int,
     default=None,
-    help="Warmup duration in milliseconds. Disables the --run-nums option."
+    help="Warmup duration in milliseconds. Disables the --run-nums option.",
 )
 def nbit_device_with_spec(  # noqa C901
     alpha: float,
@@ -1760,11 +1761,11 @@ def nbit_device_with_spec(  # noqa C901
                     per_sample_weights,
                 ),
                 check_median=check_median,
-                warmup_ms=warmup_ms
+                warmup_ms=warmup_ms,
             )
 
         # copy the request of last iteration for kineto profile benchmark
-        if (i == runs_of_iters - 1):
+        if i == runs_of_iters - 1:
             kineto_request = requests
 
         # free up memory
@@ -1815,7 +1816,7 @@ def nbit_device_with_spec(  # noqa C901
                     indices.int(),
                     offsets.int(),
                     per_sample_weights,
-                )
+                ),
             )
 
         with context_factory(
@@ -1833,7 +1834,7 @@ def nbit_device_with_spec(  # noqa C901
             )
 
         if export_trace:
-            kernel_time = time_dict['kernel_time']
+            kernel_time = time_dict["kernel_time"]
             bandwidth = read_write_bytes / kernel_time / 1.0e3
 
             logging.info(

--- a/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
+++ b/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py
@@ -1764,7 +1764,7 @@ def nbit_device_with_spec(  # noqa C901
             )
 
         # copy the request of last iteration for kineto profile benchmark
-        if (i == runs_of_iters-1):
+        if (i == runs_of_iters - 1):
             kineto_request = requests
 
         # free up memory

--- a/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
+++ b/fbgemm_gpu/experimental/gen_ai/bench/quantize_ops.py
@@ -717,6 +717,40 @@ class FP8RowwiseBatchedGemm(QuantizeOpBase):
 
 
 @register_quantize_op
+class FP8LiteGemm(QuantizeOpBase):
+    """
+    FP8 lite matmul for memory bound.
+    """
+
+    def quantize(self, x, w):
+        # Quantize both input tensors.
+        xq, x_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(x)
+        wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(w)
+        return xq, wq, x_scale, w_scale
+
+    def compute(self, xq, wq, x_scale, w_scale):
+        return torch.ops.fbgemm.f8f8bf16_lite(xq, wq, x_scale * w_scale)
+
+    def quantize_and_compute(self, x, w):
+        xq, wq, x_scale, w_scale = self.quantize(x, w)
+        return self.compute(xq, wq, x_scale * w_scale)
+
+    @property
+    def name(self) -> str:
+        return "cuda_lite"
+
+    @property
+    def hip(self) -> bool:
+        # Need to add support for better quantize kernel.
+        # Also may have an issue with cuda graphs.
+        return False
+
+    @property
+    def cuda(self) -> bool:
+        return True
+
+
+@register_quantize_op
 class TritonFP8RowwiseGemm(QuantizeOpBase):
     """
     FP8 matmul with rowwise scaling implemented with Triton.

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8_rowwise_gemm.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/fp8_rowwise_gemm.hip
@@ -40,13 +40,13 @@ struct IntTupleHash {
 static const std::unordered_map<std::tuple<int, int, int>, RowwiseKernel, IntTupleHash> rowwise_lookup_dispatch = {
     // Support for decode for [1024, 5120]
     {{16, 1024, 5120},
-     fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2},
+     fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2_8},
     {{32, 1024, 5120},
-     fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2},
+     fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2_8},
     {{64, 1024, 5120},
-     fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2},
+     fp8_rowwise_128x16x32x512_16x16_1x1_32x4x1_32x4x1_1x16x1x8_4x4x1_1x1_intrawave_v2},
     {{128, 1024, 5120},
-     fp8_rowwise_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2},
+     fp8_rowwise_128x16x32x512_16x16_1x1_32x4x1_32x4x1_1x16x1x8_4x4x1_1x1_intrawave_v2},
     // Support for decode for [5120, 1024]
     {{16, 5120, 1024},
      fp8_rowwise_128x32x16x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_2x2x1_1x1_interwave_v2},

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2_8_split_k.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2_8_split_k.hip
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fp8_rowwise_common.h"
+
+at::Tensor
+fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2_8(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor Y) {
+  using DeviceGemmInstance = DeviceGemmHelper<
+      128,
+      16,
+      32,
+      128,
+      16,
+      16,
+      1,
+      1,
+      S<8, 16, 1>,
+      S<8, 16, 1>,
+      S<1, 16, 1, 8>,
+      S<4, 4, 1>,
+      1,
+      1,
+      ck::BlockGemmPipelineScheduler::Interwave,
+      ck::BlockGemmPipelineVersion::v2,
+      ck::tensor_operation::device::GemmSpecialization::Default>;
+  // Run kernel instance.
+  return f8f8bf16_rowwise_impl<DeviceGemmInstance>(XQ, WQ, x_scale, w_scale, Y, 8);
+}

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_128x16x32x512_16x16_1x1_32x4x1_32x4x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_128x16x32x512_16x16_1x1_32x4x1_32x4x1_1x16x1x8_4x4x1_1x1_intrawave_v2.hip
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "fp8_rowwise_common.h"
+
+at::Tensor
+fp8_rowwise_128x16x32x512_16x16_1x1_32x4x1_32x4x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor Y) {
+  using DeviceGemmInstance = DeviceGemmHelper<
+      128,
+      16,
+      32,
+      512,
+      16,
+      16,
+      1,
+      1,
+      S<32, 4, 1>,
+      S<32, 4, 1>,
+      S<1, 16, 1, 8>,
+      S<4, 4, 1>,
+      1,
+      1,
+      ck::BlockGemmPipelineScheduler::Intrawave,
+      ck::BlockGemmPipelineVersion::v2,
+      ck::tensor_operation::device::GemmSpecialization::Default>;
+  // Run kernel instance.
+  return f8f8bf16_rowwise_impl<DeviceGemmInstance>(XQ, WQ, x_scale, w_scale, Y);
+}

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_common.h
@@ -160,7 +160,8 @@ at::Tensor f8f8bf16_rowwise_impl(
     at::Tensor WQ,
     at::Tensor x_scale,
     at::Tensor w_scale,
-    at::Tensor Y) {
+    at::Tensor Y,
+    int KBatch = 1) {
   // Get input information.
   int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
   int N = WQ.size(0);
@@ -194,7 +195,7 @@ at::Tensor f8f8bf16_rowwise_impl(
       StrideB,
       std::array<ck::index_t, NumDTensor>{0, 0},
       StrideE,
-      1,
+      KBatch,
       a_element_op,
       b_element_op,
       cde_element_op);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_kernel_manifest.h
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/ck_extensions/fp8_rowwise/kernels/fp8_rowwise_kernel_manifest.h
@@ -305,3 +305,19 @@ fp8_rowwise_256x256x128x128_32x32_4x2_8x32x1_8x32x1_1x32x1x8_8x8x1_1x1_intrawave
     at::Tensor x_scale,
     at::Tensor w_scale,
     at::Tensor Y);
+
+at::Tensor
+fp8_rowwise_128x16x32x128_16x16_1x1_8x16x1_8x16x1_1x16x1x8_4x4x1_1x1_interwave_v2_8(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor Y);
+
+at::Tensor
+fp8_rowwise_128x16x32x512_16x16_1x1_32x4x1_32x4x1_1x16x1x8_4x4x1_1x1_intrawave_v2(
+    at::Tensor XQ,
+    at::Tensor WQ,
+    at::Tensor x_scale,
+    at::Tensor w_scale,
+    at::Tensor Y);

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_lite.cu
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/cutlass_extensions/f8f8bf16_lite.cu
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cutlass/numeric_conversion.h>
+#include <cub/cub.cuh>
+
+namespace fbgemm_gpu {
+
+#if CUDART_VERSION >= 12000
+
+using SizeType32 = std::size_t;
+
+struct Params {
+  void const* act;
+  void const* weight;
+  void const* alpha;
+  void* output;
+  SizeType32 m, n, k;
+
+  Params(
+      void const* _act,
+      void const* _weight,
+      void const* _alpha,
+      void* _output,
+      SizeType32 _m,
+      SizeType32 _n,
+      SizeType32 _k)
+      : act(_act),
+        weight(_weight),
+        alpha(_alpha),
+        output(_output),
+        m(_m),
+        n(_n),
+        k(_k) {}
+};
+
+template <
+    typename InputType,
+    typename OutputType,
+    SizeType32 TILE_M,
+    SizeType32 TILE_N,
+    SizeType32 BLOCK_SIZE>
+__global__ void cudaCoreGemm(
+    InputType const* __restrict__ act,
+    InputType const* __restrict__ weight,
+    float const* alpha,
+    OutputType* __restrict__ output,
+    SizeType32 m,
+    SizeType32 n,
+    SizeType32 k) {
+  using VecType = int4;
+  static constexpr SizeType32 kStepK =
+      static_cast<SizeType32>(128 / (8 * sizeof(InputType)));
+  static constexpr SizeType32 kTileK = kStepK * BLOCK_SIZE;
+  auto tileIdM = static_cast<SizeType32>(blockIdx.x * TILE_M);
+  auto tileIdN = static_cast<SizeType32>(blockIdx.y * TILE_N);
+  auto tid = static_cast<SizeType32>(threadIdx.x);
+  float tile_a[kStepK], tile_w[TILE_N * kStepK];
+  float acc[TILE_M * TILE_N];
+
+  static_assert(kStepK % 4 == 0);
+  using CvtInputType = cutlass::float_e4m3_t;
+  using Converter = cutlass::NumericArrayConverter<float, CvtInputType, 4>;
+  using CvtSrcType = typename Converter::source_type;
+  using CvtResType = typename Converter::result_type;
+  static constexpr SizeType32 kCvtCount =
+      static_cast<SizeType32>(sizeof(VecType) / sizeof(CvtSrcType));
+
+#pragma unroll
+  for (SizeType32 i = 0; i < TILE_M * TILE_N; ++i) {
+    acc[i] = 0;
+  }
+  act += tileIdM * k;
+  weight += tileIdN * k;
+  output += tileIdM * n + tileIdN;
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  cudaGridDependencySynchronize();
+#endif
+
+  for (SizeType32 idxK = tid * kStepK; idxK < k; idxK += kTileK) {
+    for (SizeType32 i = 0; i < TILE_N; ++i) {
+      auto tile_w_quantized =
+          reinterpret_cast<VecType const*>(weight + i * k + idxK)[0];
+#pragma unroll
+      for (SizeType32 cvtIdx = 0; cvtIdx < kCvtCount; ++cvtIdx) {
+        reinterpret_cast<CvtResType*>(tile_w)[i * kCvtCount + cvtIdx] =
+            Converter::convert(
+                reinterpret_cast<CvtSrcType*>(&tile_w_quantized)[cvtIdx]);
+      }
+    }
+#pragma unroll
+    for (SizeType32 i = 0; i < TILE_M; ++i) {
+      auto tile_a_quantized =
+          reinterpret_cast<VecType const*>(act + i * k + idxK)[0];
+#pragma unroll
+      for (SizeType32 cvtIdx = 0; cvtIdx < kCvtCount; ++cvtIdx) {
+        reinterpret_cast<CvtResType*>(tile_a)[cvtIdx] = Converter::convert(
+            reinterpret_cast<CvtSrcType*>(&tile_a_quantized)[cvtIdx]);
+      }
+#pragma unroll
+      for (SizeType32 j = 0; j < TILE_N; ++j) {
+#pragma unroll
+        for (SizeType32 l = 0; l < kStepK; ++l) {
+          acc[i * TILE_N + j] =
+              fma(tile_a[l], tile_w[j * kStepK + l], acc[i * TILE_N + j]);
+        }
+      }
+    }
+  }
+
+  typedef cub::WarpReduce<float> WarpReduce;
+
+  static constexpr SizeType32 kWarpSize = 32;
+  static constexpr SizeType32 kWarpNum = BLOCK_SIZE / kWarpSize;
+  SizeType32 warpId = tid / kWarpSize, laneId = tid % kWarpSize;
+  __shared__ float shmem[TILE_M * TILE_N * kWarpNum];
+  __shared__ typename WarpReduce::TempStorage tempStorage[kWarpNum];
+#pragma unroll
+  for (SizeType32 mi = 0; mi < TILE_M; ++mi) {
+#pragma unroll
+    for (SizeType32 ni = 0; ni < TILE_N; ++ni) {
+      float val = WarpReduce(tempStorage[warpId]).Sum(acc[mi * TILE_N + ni]);
+      if (laneId == 0) {
+        shmem[mi * TILE_N + ni + warpId * TILE_M * TILE_N] = val;
+      }
+    }
+  }
+  __syncthreads();
+  for (SizeType32 ii = tid; ii < TILE_M * TILE_N; ii += BLOCK_SIZE) {
+    SizeType32 mid = ii / TILE_N, nid = ii % TILE_N;
+    float val = 0;
+#pragma unroll
+    for (SizeType32 jj = 0; jj < kWarpNum; ++jj) {
+      val += shmem[jj * TILE_M * TILE_N + ii];
+    }
+    output[mid * n + nid] = static_cast<OutputType>(val * *alpha);
+  }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+template <
+    typename InputType,
+    typename OutputType,
+    SizeType32 TILE_M,
+    SizeType32 TILE_N,
+    SizeType32 BLOCK_SIZE>
+void cudaCoreGemmKernel(Params const& params, cudaStream_t stream) {
+  dim3 block(BLOCK_SIZE);
+  dim3 grid(params.m / TILE_M, params.n / TILE_N);
+
+  cudaCoreGemm<InputType, OutputType, TILE_M, TILE_N, BLOCK_SIZE>
+      <<<grid, block, 0, stream>>>(
+          reinterpret_cast<InputType const*>(params.act),
+          reinterpret_cast<InputType const*>(params.weight),
+          reinterpret_cast<float const*>(params.alpha),
+          reinterpret_cast<OutputType*>(params.output),
+          params.m,
+          params.n,
+          params.k);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <
+    typename InputType,
+    typename OutputType,
+    int TILE_M,
+    int TILE_N,
+    int BLOCK_SIZE>
+bool cudaCoreGemmTemplateCaller(Params const& params, cudaStream_t stream) {
+  constexpr int cudaCoreGemmTemplateMaxM = 128;
+  if (params.m == TILE_M) {
+    cudaCoreGemmKernel<InputType, OutputType, TILE_M, TILE_N, BLOCK_SIZE>(
+        params, stream);
+    return true;
+  }
+  if constexpr (TILE_M < cudaCoreGemmTemplateMaxM) {
+    return cudaCoreGemmTemplateCaller<
+        InputType,
+        OutputType,
+        TILE_M + 1,
+        TILE_N,
+        BLOCK_SIZE>(params, stream);
+  }
+  return false;
+}
+
+template <typename InputType, typename OutputType>
+bool cudaCoreGemmLauncher(Params const& params, cudaStream_t stream) {
+  return cudaCoreGemmTemplateCaller<InputType, OutputType, 1, 2, 128>(
+      params, stream);
+}
+
+at::Tensor f8f8bf16_lite(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor scale) {
+  bool dispatched = true;
+  int M = size_to_dim_(XQ.dim() - 1, XQ.sizes());
+  int N = WQ.size(0);
+  int K = WQ.size(1);
+  TORCH_CHECK(XQ.size(-1) == K);
+
+  if (M > 128) {
+    throw std::runtime_error("f8f8bf16_lite cannot run when M > 128");
+  } else if (N % 2 != 0) {
+    throw std::runtime_error("f8f8bf16_lite cannot run when N % 2 != 0");
+  } else if (K % 16 != 0) {
+    throw std::runtime_error("f8f8bf16_lite cannot run when K % 16 != 0");
+  }
+
+  auto out_sizes = XQ.sizes().vec();
+  out_sizes.back() = N;
+  at::Tensor Y = at::empty(out_sizes, XQ.options().dtype(at::kBFloat16));
+
+  Params params{
+      XQ.data_ptr(),
+      WQ.data_ptr(),
+      scale.data_ptr(),
+      Y.data_ptr(),
+      (SizeType32)M,
+      (SizeType32)N,
+      (SizeType32)K};
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  dispatched = cudaCoreGemmLauncher<cutlass::float_e4m3_t, __nv_bfloat16>(
+      params, stream);
+  if (!dispatched) {
+    throw std::runtime_error("f8f8bf16_lite cannot run");
+  }
+  return Y;
+}
+
+#else
+
+at::Tensor f8f8bf16_lite(
+    at::Tensor XQ, // FP8
+    at::Tensor WQ, // FP8
+    at::Tensor scale) {
+  throw std::runtime_error(
+      "CUDA version is older than 12.0"); // requires CUDA>=12
+}
+
+#endif
+
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
+++ b/fbgemm_gpu/experimental/gen_ai/src/quantize/quantize.cpp
@@ -55,6 +55,7 @@ at::Tensor f8f8bf16_tensorwise(
     at::Tensor WQ,
     double scale,
     bool use_fast_accum = true);
+at::Tensor f8f8bf16_lite(at::Tensor XQ, at::Tensor WQ, at::Tensor scale);
 std::vector<at::Tensor> f8f8bf16_grouped(
     at::TensorList XQ,
     at::TensorList WQ,
@@ -187,6 +188,7 @@ TORCH_LIBRARY_FRAGMENT(fbgemm, m) {
       "f8i4bf16_rowwise(Tensor XQ, Tensor WQ, Tensor x_scale, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def(
       "f8f8bf16_grouped(Tensor[] XQ, Tensor[] WQ, Tensor[] scale, Tensor? zero_start_index_M=None, bool use_fast_accum=True) -> Tensor[]");
+  m.def("f8f8bf16_lite(Tensor XQ, Tensor WQ, Tensor scale) -> Tensor");
   m.def(
       "bf16i4bf16_rowwise(Tensor X, Tensor WQ, Tensor w_scale, Tensor w_zp) -> Tensor");
   m.def(
@@ -268,6 +270,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CUDA, m) {
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("f8f8bf16_grouped", f8f8bf16_grouped);
+  m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise);
@@ -295,6 +298,7 @@ TORCH_LIBRARY_IMPL(fbgemm, CPU, m) {
   m.impl("f8f8bf16", f8f8bf16);
   m.impl("f8f8bf16_cublas", f8f8bf16_cublas);
   m.impl("f8f8bf16_grouped", f8f8bf16_grouped);
+  m.impl("f8f8bf16_lite", f8f8bf16_lite);
   m.impl("f8i4bf16_rowwise", f8i4bf16_rowwise);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched);
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise);
@@ -409,6 +413,13 @@ at::Tensor f8f8bf16_tensorwise_meta(
     at::Tensor W,
     double scale,
     bool use_fast_accum = true) {
+  const at::SymInt M = X.sym_size(0);
+  const at::SymInt N = W.sym_size(0);
+  auto Y = at::empty_symint({M, N}, X.options().dtype(at::kBFloat16));
+  return Y;
+}
+
+at::Tensor f8f8bf16_lite_meta(at::Tensor X, at::Tensor W, at::Tensor scale) {
   const at::SymInt M = X.sym_size(0);
   const at::SymInt N = W.sym_size(0);
   auto Y = at::empty_symint({M, N}, X.options().dtype(at::kBFloat16));
@@ -533,6 +544,7 @@ TORCH_LIBRARY_IMPL(fbgemm, Meta, m) {
   m.impl("bf16i4bf16_rowwise", bf16i4bf16_rowwise_meta);
   m.impl("bf16i4bf16_rowwise_batched", bf16i4bf16_rowwise_batched_meta);
   m.impl("f8f8bf16_grouped", f8f8bf16_grouped_meta);
+  m.impl("f8f8bf16_lite", f8f8bf16_lite_meta);
 #endif
 }
 

--- a/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
+++ b/fbgemm_gpu/experimental/gen_ai/test/quantize/quantize_test.py
@@ -1110,6 +1110,30 @@ class FP8Tests(unittest.TestCase):
         torch.testing.assert_close(w.shape, wq.shape)
         torch.testing.assert_close(w_scale.shape, w_scale_ref.shape)
 
+    @unittest.skipIf(torch.version.hip, "Skip on AMD: fp8 lite op is yet suported.")
+    @settings(deadline=None)
+    @given(
+        M=st.sampled_from([1, 5, 16]),
+        N=st.sampled_from([1024, 6144]),
+        K=st.sampled_from([512, 3584]),
+        CudaGraph=st.sampled_from([True, False]),
+    )
+    def test_fp8_lite_matmul(self, M: int, N: int, K: int, CudaGraph: bool) -> None:
+        x = torch.randn(size=(M, K), dtype=torch.bfloat16, device="cuda") * 0.1
+        w = torch.randn(size=(N, K), dtype=torch.bfloat16, device="cuda") * 0.01
+        xq, x_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(x)
+        wq, w_scale = torch.ops.fbgemm.quantize_fp8_per_tensor(w)
+        if CudaGraph:
+            zq = torch.ops.fbgemm.f8f8bf16_lite(xq, wq, x_scale * w_scale)
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g):
+                zq = torch.ops.fbgemm.f8f8bf16_lite(xq, wq, x_scale * w_scale)
+            g.replay()
+        else:
+            zq = torch.ops.fbgemm.f8f8bf16_lite(xq, wq, x_scale * w_scale)
+        zq_ref = (x @ w.T).to(torch.bfloat16)
+        torch.testing.assert_close(zq, zq_ref, atol=9.0e-2, rtol=9.0e-2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

**Summary**
This PR introduces:
A new warm-up method to ensure sufficient GPU preparation before benchmarking.
Benchmark time calculation using the Kineto profiler for measuring the time and bandwidth of inference forward kernels.
 
**Motivation**
In small benchmark cases, kernel launch and synchronization overheads can be significant compared to the actual kernel runtime. By leveraging the Kineto profiler:
These overheads are eliminated.
Users get a more accurate estimation of kernel execution time and bandwidth of the forward kernel.

For small kernels the iteration based warm-up might not be sufficient.
By leveraging the time based warmup:
Users will be confident the GPU has done enough warm-up.

**Test instruction**
The below script shows how to use this features: 
python bench/split_table_batched_embeddings_benchmark.py nbit-device-with-spec **--export-trace --warmup_ms 50**
