### PR TITLE
Reduce MaxNum128BRows for ROCM devices

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -102,7 +102,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
 
   for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
     const uint32_t packed_bag_idx = PackedMode ? (threadIdx.x % NumUint4LoadsPerRow) / uint4_loads_per_row : 0;
-    uint32_t b = min(static_cast<uint32_t>(bb * num_packed_bags * OutputRowsPerThread + i * num_packed_bags + packed_bag_idx), static_cast<uint32_t>(B - 1));
+    uint32_t b = PackedMode ? min(static_cast<uint32_t>(bb * num_packed_bags * OutputRowsPerThread + i * num_packed_bags + packed_bag_idx), static_cast<uint32_t>(B - 1))
+                            : min(static_cast<uint32_t>(bb * OutputRowsPerThread + i), static_cast<uint32_t>(B - 1));
     int32_t indices_start = offsets[t * B + b];
     int32_t indices_end = offsets[t * B + b + 1];
     indices_starts[i] = indices_start;
@@ -262,11 +263,11 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         // rationale: have scale/shift at start since these get loaded first
         // and then broadcasted around so it might speed up the first cache miss.
         {% if emb_weight_type.primitive_type == "INT" %}
-        half2 shift_scale = reinterpret_cast<const half2*>(row)[packed_bag_idx * uints_per_row];
+        half2 shift_scale = reinterpret_cast<const half2*>(row)[PackedMode ? packed_bag_idx * uints_per_row : 0];
         {% endif %}
 
         {% if weighted %}
-        float row_weight = buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_idx];
+        float row_weight = buffers_indice_weights[warp_idx][i][input_row_idx][PackedMode ? packed_bag_idx : 0];
         {% endif %}
 
         using scalar_t = {{ emb_weight_type.cpp_type_name }};
@@ -351,9 +352,16 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         }
         accumulators[i][j].mul(inv_L);
 
-        if (output_d >= 0 && output_d < D && (!PackedMode || packed_bag_idx < num_packed_bags)) {
-          const int num_valid_outputs = min(static_cast<int>(D - output_d), static_cast<int>({{ (32 // emb_weight_type.bit_width) }}));
-          accumulators[i][j].store(&output[b][D_start + output_d], num_valid_outputs);
+        if constexpr (PackedMode) {
+          if (output_d >= 0 && output_d < D && packed_bag_idx < num_packed_bags) {
+            const int num_valid_outputs = min(static_cast<int>(D - output_d), static_cast<int>({{ (32 // emb_weight_type.bit_width) }}));
+            accumulators[i][j].store(&output[b][D_start + output_d], num_valid_outputs);
+          }
+        } else {
+          if (output_d >= 0 && output_d < D) {
+            const int num_valid_outputs = min(static_cast<int>(D - output_d), static_cast<int>({{ (32 // emb_weight_type.bit_width) }}));
+            accumulators[i][j].store(&output[b][D_start + output_d], num_valid_outputs);
+          }
         }
 
       }

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -85,7 +85,11 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   if (D_bytes <= MinNum128BRows * 128 || D_bytes > MaxNum128BRows * 128) {
     return;
   }
-
+  {%- if kWarpSize==64 %}
+    constexpr int32_t MaxNum128BRows_req = (MaxNum128BRows+1) / 2;
+  {%- else %}
+    constexpr int32_t MaxNum128BRows_req = MaxNum128BRows;
+  {%- endif %}
 
   const int64_t weights_offset = weights_offsets[t];
   const int32_t D_total = padded_D(D, weight_ty);
@@ -121,7 +125,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   }
 
   {% if not nobag %}
-  VecNT<{{ (32 // emb_weight_type.bit_width) }}, PrimitiveType::{{ emb_weight_type.primitive_type }}> accumulators[OutputRowsPerThread][MaxNum128BRows];
+  VecNT<{{ (32 // emb_weight_type.bit_width) }}, PrimitiveType::{{ emb_weight_type.primitive_type }}> accumulators[OutputRowsPerThread][MaxNum128BRows_req];
   {% endif %}
 
   for (uint32_t L_start = 0; L_start < max_Ls; L_start += InputRowsInFlight) {
@@ -273,8 +277,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         using scalar_t = {{ emb_weight_type.cpp_type_name }};
 
         {% if not nobag %}
-        #pragma unroll MaxNum128BRows
-        for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
+        #pragma unroll MaxNum128BRows_req
+        for (uint32_t j = 0; j < MaxNum128BRows_req; ++j) {
           scalar_t v = reinterpret_cast<const scalar_t*>(row)[kWarpSize * j + threadIdx.x];
           {% if weighted %}
           accumulators[i][j].fma(v, {% if emb_weight_type.primitive_type == "INT" %} shift_scale, {% elif emb_weight_type.enum_name == "FP8" %} exponent_bits, exponent_bias, {% endif %} row_weight);
@@ -285,8 +289,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         {% else %}
         const int32_t output_j = indices_starts[i] + L_start + input_row_idx;
         if constexpr (std::is_same_v<output_t, float> || std::is_same_v<output_t, at::Half> || std::is_same_v<output_t, at::BFloat16>) {
-          #pragma unroll MaxNum128BRows
-          for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
+          #pragma unroll MaxNum128BRows_req
+          for (uint32_t j = 0; j < MaxNum128BRows_req; ++j) {
             // Read the uint8/4/2 values: note that first 4 Bytes will be ditched later:
             // We shift back by 4/8/16 elements to remove the first 4 Bytes (which is garbage due to
             // the scale/shift handling).
@@ -305,8 +309,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           auto thread_local_min = std::numeric_limits<float>::max();
           auto thread_local_max = std::numeric_limits<float>::lowest();
           float2 qparams;
-          #pragma unroll MaxNum128BRows
-          for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
+          #pragma unroll MaxNum128BRows_req
+          for (uint32_t j = 0; j < MaxNum128BRows_req; ++j) {
             int32_t output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding;
             scalar_t v = reinterpret_cast<const scalar_t*>(row)[kWarpSize * j + threadIdx.x];
             VecNT<{{ (32 // emb_weight_type.bit_width) }}, PrimitiveType::{{ emb_weight_type.primitive_type }}> acc(v{% if emb_weight_type.primitive_type == "INT" %}, shift_scale {% elif emb_weight_type.enum_name == "FP8" %}, exponent_bits, exponent_bias {% endif %});
@@ -316,8 +320,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
             }
           }
           qparams = warp_find_qparams(thread_local_min, thread_local_max);
-          #pragma unroll MaxNum128BRows
-          for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
+          #pragma unroll MaxNum128BRows_req
+          for (uint32_t j = 0; j < MaxNum128BRows_req; ++j) {
             const int32_t output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding;
             scalar_t v = reinterpret_cast<const scalar_t*>(row)[kWarpSize * j + threadIdx.x];
             if (output_d >= 0 && output_d < D) {
@@ -344,8 +348,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
     const float inv_L = (mean_pooling && Ls[i] != 0) ? static_cast<float>(1.0) / Ls[i] : static_cast<float>(1.0);
 
     if constexpr (std::is_same_v<output_t, float> || std::is_same_v<output_t, at::Half> || std::is_same_v<output_t, at::BFloat16>) {
-      #pragma unroll MaxNum128BRows
-      for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
+      #pragma unroll MaxNum128BRows_req
+      for (uint32_t j = 0; j < MaxNum128BRows_req; ++j) {
         int32_t output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding;
         if constexpr (PackedMode) {
           output_d -= packed_bag_idx * kOutputsPerThread * num_stores_with_padding_per_row; 
@@ -371,8 +375,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
       float thread_local_min = std::numeric_limits<float>::max();
       float thread_local_max = std::numeric_limits<float>::lowest();
       float2 qparams;
-      #pragma unroll MaxNum128BRows
-      for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
+      #pragma unroll MaxNum128BRows_req
+      for (uint32_t j = 0; j < MaxNum128BRows_req; ++j) {
         int32_t output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding;
         accumulators[i][j].mul(inv_L);
         if (output_d >= 0 && output_d < D) {
@@ -384,8 +388,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
       qparams = warp_find_qparams(thread_local_min, thread_local_max);
       const int output_D_start = D_start + t * 8;
       const int output_D_end = output_D_start + D;
-      #pragma unroll MaxNum128BRows
-      for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
+      #pragma unroll MaxNum128BRows_req
+      for (uint32_t j = 0; j < MaxNum128BRows_req; ++j) {
         const int32_t output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding;
         if (output_d >= 0 && output_d < D) {
           const int num_valid_outputs = min(static_cast<int>(D - output_d), static_cast<int>({{ (32 // emb_weight_type.bit_width) }}));

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -101,7 +101,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   const uint32_t uint4_loads_per_row = div_round_up(D_bytes, sizeof(uint4));
 
   for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
-    const uint32_t packed_bag_idx = num_packed_bags > 1 ? (threadIdx.x % NumUint4LoadsPerRow) / uint4_loads_per_row : 0;
+    const uint32_t packed_bag_idx = PackedMode ? (threadIdx.x % NumUint4LoadsPerRow) / uint4_loads_per_row : 0;
     uint32_t b = min(static_cast<uint32_t>(bb * num_packed_bags * OutputRowsPerThread + i * num_packed_bags + packed_bag_idx), static_cast<uint32_t>(B - 1));
     int32_t indices_start = offsets[t * B + b];
     int32_t indices_end = offsets[t * B + b + 1];
@@ -130,15 +130,18 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
     __shared__ AllBuffers buffers;
 
     {% if weighted %}
-    typedef float AllIndiceWeights[WarpsPerBlock][OutputRowsPerThread][InputRowsInFlight][NumUint4LoadsPerRow];
+    typedef float AllIndiceWeights[WarpsPerBlock][OutputRowsPerThread][InputRowsInFlight][PackedMode ? NumUint4LoadsPerRow : 0];
     __shared__ AllIndiceWeights buffers_indice_weights;
     {% endif %}
 
     for (uint32_t load_idx = threadIdx.x; load_idx < input_rows_in_flight * NumUint4LoadsPerRow; load_idx += kWarpSize) {
-      uint32_t row_load_idx = load_idx % NumUint4LoadsPerRow % uint4_loads_per_row;
+      uint32_t row_load_idx = load_idx % NumUint4LoadsPerRow;
+      if constexpr (PackedMode) {
+        row_load_idx %= uint4_loads_per_row;
+      }
       uint32_t input_row_idx = (load_idx / NumUint4LoadsPerRow);
-      const uint32_t packed_bag_idx = (threadIdx.x % NumUint4LoadsPerRow) / uint4_loads_per_row;
-      bool load_idx_valid = packed_bag_idx < num_packed_bags;
+      const uint32_t packed_bag_idx = PackedMode ? (load_idx % NumUint4LoadsPerRow) / uint4_loads_per_row : 0;
+      bool load_idx_valid = PackedMode ? packed_bag_idx < num_packed_bags : packed_bag_idx < num_packed_bags;
       {%- if is_rocm %}
       constexpr uint32_t kMaxRowUnroll = 4;
       constexpr uint32_t kRowUnroll = OutputRowsPerThread < kMaxRowUnroll ? OutputRowsPerThread : kMaxRowUnroll;
@@ -185,7 +188,11 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           uint32_t i = outer_i + inner_i;
           bool valid = load_idx_valid && (L_start + input_row_idx < Ls[i]) && (idx_v[inner_i] != -1);
           uint4 data = valid ? row_data_v[inner_i] : zeros;
-          buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_idx] = data;
+          if constexpr (PackedMode) {
+            buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_idx] = data;
+          } else {
+            buffers[warp_idx][i][input_row_idx][row_load_idx] = data;
+          }
           {% if weighted %}
           buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_idx] = valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
           {% endif %}
@@ -215,8 +222,11 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         } else {
           row = reinterpret_cast<const uint4*>(&weights[0]);
         }
-        cp_async_zfill_cg<sizeof(uint4)>(&buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_idx], &row[row_load_idx], valid);
-
+        if constexpr (PackedMode) {
+          cp_async_zfill_cg<sizeof(uint4)>(&buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_idx], &row[row_load_idx], valid);
+        } else {
+          cp_async_zfill_cg<sizeof(uint4)>(&buffers[warp_idx][i][input_row_idx][row_load_idx], &row[row_load_idx], valid);
+        }
         {% if weighted %}
         buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_idx] = valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
         {% endif %}
@@ -229,12 +239,14 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
     cp_async_wait<0>();
     syncwarp();
     const int32_t uints_per_row = 4 * uint4_loads_per_row;
-    input_rows_in_flight = shfl_sync(input_rows_in_flight, threadIdx.x / uints_per_row % num_packed_bags * uint4_loads_per_row);
-    
-    #pragma unroll OutputRowsPerThread
-    for(uint32_t i = 0; i < OutputRowsPerThread; ++i)
-    {
-      Ls[i] = shfl_sync(Ls[i], threadIdx.x / uints_per_row % num_packed_bags * uint4_loads_per_row);
+    if constexpr (PackedMode) {
+      input_rows_in_flight = shfl_sync(input_rows_in_flight, threadIdx.x / uints_per_row % num_packed_bags * uint4_loads_per_row);
+
+      #pragma unroll OutputRowsPerThread
+      for(uint32_t i = 0; i < OutputRowsPerThread; ++i)
+      {
+        Ls[i] = shfl_sync(Ls[i], threadIdx.x / uints_per_row % num_packed_bags * uint4_loads_per_row);
+      }
     }
     for (uint32_t input_row_idx = 0; input_row_idx < input_rows_in_flight; ++input_row_idx) {
       #pragma unroll OutputRowsPerThread
@@ -244,7 +256,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           continue;
         }
         const uint32_t* row = reinterpret_cast<const uint32_t*>(&buffers[warp_idx][i][input_row_idx][0]);
-        const int32_t packed_bag_idx = (threadIdx.x / uints_per_row) % num_packed_bags;
+        const int32_t packed_bag_idx = PackedMode ? (threadIdx.x / uints_per_row) % num_packed_bags : 0;
         // scale and bias are at the beginning of each row.
         // rationale: have scale/shift at start since these get loaded first
         // and then broadcasted around so it might speed up the first cache miss.
@@ -325,17 +337,20 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
   #pragma unroll OutputRowsPerThread
   for (uint32_t i = 0; i < OutputRowsPerThread; ++i) {
     const int32_t num_stores_with_padding_per_row = 4 * uint4_loads_per_row; 
-    const int32_t packed_bag_idx = threadIdx.x / num_stores_with_padding_per_row;
+    const int32_t packed_bag_idx = PackedMode ? threadIdx.x / num_stores_with_padding_per_row : 0;
     const uint32_t b = min(static_cast<uint32_t>(bb * num_packed_bags * OutputRowsPerThread + i * num_packed_bags + packed_bag_idx), static_cast<uint32_t>(B - 1));
     const float inv_L = (mean_pooling && Ls[i] != 0) ? static_cast<float>(1.0) / Ls[i] : static_cast<float>(1.0);
 
     if constexpr (std::is_same_v<output_t, float> || std::is_same_v<output_t, at::Half> || std::is_same_v<output_t, at::BFloat16>) {
       #pragma unroll MaxNum128BRows
       for (uint32_t j = 0; j < MaxNum128BRows; ++j) {
-        const int32_t output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding - packed_bag_idx * kOutputsPerThread * num_stores_with_padding_per_row;
+        int32_t output_d = kWarpSize * j * kOutputsPerThread + threadIdx.x * kOutputsPerThread - D_padding;
+        if constexpr (PackedMode) {
+          output_d -= packed_bag_idx * kOutputsPerThread * num_stores_with_padding_per_row; 
+        }
         accumulators[i][j].mul(inv_L);
 
-        if (output_d >= 0 && output_d < D && packed_bag_idx < num_packed_bags) {
+        if (output_d >= 0 && output_d < D && (!PackedMode || packed_bag_idx < num_packed_bags)) {
           const int num_valid_outputs = min(static_cast<int>(D - output_d), static_cast<int>({{ (32 // emb_weight_type.bit_width) }}));
           accumulators[i][j].store(&output[b][D_start + output_d], num_valid_outputs);
         }

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -141,7 +141,7 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
       }
       uint32_t input_row_idx = (load_idx / NumUint4LoadsPerRow);
       const uint32_t packed_bag_idx = PackedMode ? (load_idx % NumUint4LoadsPerRow) / uint4_loads_per_row : 0;
-      bool load_idx_valid = PackedMode ? packed_bag_idx < num_packed_bags : packed_bag_idx < num_packed_bags;
+      bool load_idx_valid = PackedMode ? packed_bag_idx < num_packed_bags : row_load_idx < uint4_loads_per_row;
       {%- if is_rocm %}
       constexpr uint32_t kMaxRowUnroll = 4;
       constexpr uint32_t kRowUnroll = OutputRowsPerThread < kMaxRowUnroll ? OutputRowsPerThread : kMaxRowUnroll;


### PR DESCRIPTION
This commit reduces the number of iterations in accumulation and load stages for ROCM devices by taking advantage of larger warp size of AMD devices. 
